### PR TITLE
fix: Send as json type

### DIFF
--- a/src/healthcheck.js
+++ b/src/healthcheck.js
@@ -37,7 +37,7 @@ function healthcheck(packageJSON, additonalMetrics = {}) {
 
     return (req, res) => {
         if (res.send) {
-            res.json(JSON.stringify(metrics(), null, 2));
+            res.json(metrics());
         } else {
             res(JSON.stringify(metrics(), null, 2));
         }


### PR DESCRIPTION
The healthcheck was getting stringified twice due to express's
response.json function which sets the headers and stringifies the
json object passed in.