### PR TITLE
first pass at adding hapi plugin registration

### DIFF
--- a/example.js
+++ b/example.js
@@ -31,12 +31,35 @@ function send(handler, response) {
 
 const frameworks = ['hapi', 'express'];
 
+// simple plugin based on tutorial, https://hapijs.com/tutorials/plugins
+const myHapiPlugin = {
+    register: function (server, options, next) {
+      log.important(`myHapiPlugin options, Port ${server.info.port}: `,options);
+      server.route({
+        method: 'GET',
+        path: '/myHapiPluginOptions',
+        handler: function (request, reply) {
+            reply({ myHapiPluginOptions : options});
+        }
+      });
+      next();
+    }
+};
+
+myHapiPlugin.register.attributes = {
+    name: 'myHapiPlugin',
+    version: '1.0.0'
+};
+
+const myHapiPluginOptions = [{ foo : 'bar'},{ bar : 'foo'},{ foobar : true}];
+
 for (let port = 5000; port < 5005; port++) {
     const framework = frameworks[Math.floor(Math.random() * frameworks.length)];
     server({
         port,
         framework,
-        routes: [ { path: '/foo', handler: (req, res) => send(res, framework) } ]
+        routes: [ { path: '/foo', handler: (req, res) => send(res, framework) } ],
+        plugins: [ { register: myHapiPlugin, options: myHapiPluginOptions[Math.floor(Math.random() * myHapiPluginOptions.length)] }]
     });
 }
 


### PR DESCRIPTION
I was working on a proof of concept idea using **cnn-starter** and wanted to use the **hapi-mongodb** plugin and discovered that **cnn-starter** didn't support plugins yet..

I pretty much just followed the established pattern for registering hapi routes and used what I read about Hapi plugin registration in the [hapi plugin tutorial](https://hapijs.com/tutorials/plugins).
When testing this out locally I was able to register an array of plugins (like **hapi-cron**, **hapi-mongodb**, **inert**, etc).

I also added an a simple hapi plugin (based on examples in the  [hapi plugin tutorial](https://hapijs.com/tutorials/plugins)) to _example.js_