### PR TITLE
Add type checking for middleware list

### DIFF
--- a/src/express.js
+++ b/src/express.js
@@ -43,9 +43,16 @@ function registerMiddleware(app, express, config, callback) {
     enableCompression && app.use(require('compression')());
     enableStatic && app.use(staticPath, express.static(staticDirectory));
 
-    middleware.forEach(({ path = '/', handler }) => {
-        log.important(`Registering middleware: ${path}`);
-        app.use.call(app, path, handler);
+    middleware.forEach(middleware => {
+        if (typeof middleware === 'function') {
+            log.important(`Registering middleware: ${middleware.name}`);
+            app.use.call(app, middleware);
+        } else {
+            const { path = '/', handler } = middleware;
+
+            log.important(`Registering middleware: ${path}`);
+            app.use.call(app, path, handler);
+        }
     });
 
     callback();


### PR DESCRIPTION
Currently `cnn-server` assumes that middlewares adhere to an object structure like

```js
{
  path: '/',
  handler: (req, res, next) => {
    // amazing things
  }
}
```

In the case of application middleware, it may not be necessary to assume a path, so `cnn-server` should support arrays of functions.