### PR TITLE
add support for cluster, add debug, update logging

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 /*.log
 .DS_Store
 .idea
+package-lock.json

--- a/README.md
+++ b/README.md
@@ -10,3 +10,8 @@ TODO... Until then, check out `example.js`.
 | `ENABLE_COMPRESSION` | Enables `compression` middleware. | `false` |
 | `ENABLE_STATIC` | Enables ability to serve static assets. | `false` |
 | `ENABLE_CLUSTER` | Turns on clustering, forking to available cores. | `false` |
+| `LOGZIO_TOKEN` | Used for logz.io transport (REQUIRED for logging to logz.io) | none |
+| `PRODUCT` | Your product's name (REQUIRED for logging to logz.io) | none |
+| `ENGIRONMENT` | Environment your product runs in (REQUIRED for logging to logz.io) | none |
+| `LOG_LEVEL` | Log level used for logz.io and as a fallback for stdout | `important` |
+| `CONSOLE_LOG_LEVEL` | Log level used for stdout | `important` |

--- a/README.md
+++ b/README.md
@@ -11,7 +11,6 @@ TODO... Until then, check out `example.js`.
 | `ENABLE_STATIC` | Enables ability to serve static assets. | `false` |
 | `ENABLE_CLUSTER` | Turns on clustering, forking to available cores. | `false` |
 | `LOGZIO_TOKEN` | Used for logz.io transport (REQUIRED for logging to logz.io) | none |
-| `PRODUCT` | Your product's name (REQUIRED for logging to logz.io) | none |
-| `ENVIRONMENT` | Environment your product runs in (REQUIRED for logging to logz.io) | none |
+| `LOGZIO_TAGS` | A comma-delimited string of tags you want passed to logz.io (REQUIRED for logging to logz.io) | none |
 | `LOG_LEVEL` | Log level used for logz.io and as a fallback for stdout | `important` |
 | `CONSOLE_LOG_LEVEL` | Log level used for stdout | `important` |

--- a/README.md
+++ b/README.md
@@ -12,6 +12,6 @@ TODO... Until then, check out `example.js`.
 | `ENABLE_CLUSTER` | Turns on clustering, forking to available cores. | `false` |
 | `LOGZIO_TOKEN` | Used for logz.io transport (REQUIRED for logging to logz.io) | none |
 | `PRODUCT` | Your product's name (REQUIRED for logging to logz.io) | none |
-| `ENGIRONMENT` | Environment your product runs in (REQUIRED for logging to logz.io) | none |
+| `ENVIRONMENT` | Environment your product runs in (REQUIRED for logging to logz.io) | none |
 | `LOG_LEVEL` | Log level used for logz.io and as a fallback for stdout | `important` |
 | `CONSOLE_LOG_LEVEL` | Log level used for stdout | `important` |

--- a/README.md
+++ b/README.md
@@ -1,3 +1,12 @@
 # CNN Server
 
 TODO... Until then, check out `example.js`.
+
+## Supported Environment Variables
+
+| Variable | Description | Default |
+| -------- | ----------- | ------- |
+| `PORT`   | Port for application to listen on. | `5050` |
+| `ENABLE_COMPRESSION` | Enables `compression` middleware. | `false` |
+| `ENABLE_STATIC` | Enables ability to serve static assets. | `false` |
+| `ENABLE_CLUSTER` | Turns on clustering, forking to available cores. | `false` |

--- a/example.js
+++ b/example.js
@@ -25,54 +25,54 @@ const server = require('./src/index.js');
 
 // Fun with frameworks
 // -----------------------------------------------------------------------------
-function send(handler, response) {
-    (handler && handler.send) ? handler.send(response) : handler(response);
-}
+// function send(handler, response) {
+//     (handler && handler.send) ? handler.send(response) : handler(response);
+// }
 
-const frameworks = ['hapi', 'express'];
+// const frameworks = ['hapi', 'express'];
 
-// simple plugin based on tutorial, https://hapijs.com/tutorials/plugins
-const myHapiPlugin = {
-    register: function (server, options, next) {
-      log.important(`myHapiPlugin options, Port ${server.info.port}: `,options);
-      server.route({
-        method: 'GET',
-        path: '/myHapiPluginOptions',
-        handler: function (request, reply) {
-            reply({ myHapiPluginOptions : options});
-        }
-      });
-      next();
-    }
-};
+// // simple plugin based on tutorial, https://hapijs.com/tutorials/plugins
+// const myHapiPlugin = {
+//     register: function (server, options, next) {
+//       log.important(`myHapiPlugin options, Port ${server.info.port}: `,options);
+//       server.route({
+//         method: 'GET',
+//         path: '/myHapiPluginOptions',
+//         handler: function (request, reply) {
+//             reply({ myHapiPluginOptions : options});
+//         }
+//       });
+//       next();
+//     }
+// };
 
-myHapiPlugin.register.attributes = {
-    name: 'myHapiPlugin',
-    version: '1.0.0'
-};
+// myHapiPlugin.register.attributes = {
+//     name: 'myHapiPlugin',
+//     version: '1.0.0'
+// };
 
-const myHapiPluginOptions = [{ foo : 'bar'},{ bar : 'foo'},{ foobar : true}];
+// const myHapiPluginOptions = [{ foo : 'bar'},{ bar : 'foo'},{ foobar : true}];
 
-for (let port = 5000; port < 5005; port++) {
-    const framework = frameworks[Math.floor(Math.random() * frameworks.length)];
-    server({
-        port,
-        framework,
-        routes: [ { path: '/foo', handler: (req, res) => send(res, framework) } ],
-        plugins: [ { register: myHapiPlugin, options: myHapiPluginOptions[Math.floor(Math.random() * myHapiPluginOptions.length)] }]
-    });
-}
+// for (let port = 5000; port < 5005; port++) {
+//     const framework = frameworks[Math.floor(Math.random() * frameworks.length)];
+//     server({
+//         port,
+//         framework,
+//         routes: [ { path: '/foo', handler: (req, res) => send(res, framework) } ],
+//         plugins: [ { register: myHapiPlugin, options: myHapiPluginOptions[Math.floor(Math.random() * myHapiPluginOptions.length)] }]
+//     });
+// }
 
 // Define a route
 // -----------------------------------------------------------------------------
-// server({
-//     routes: [
-//         {
-//             path: '/foo',
-//             handler: (req, res) => res.json({ foo: 'Hello World!' })
-//         }
-//     ]
-// });
+server({
+    routes: [
+        {
+            path: '/foo',
+            handler: (req, res) => res.json({ foo: 'Hello World!' })
+        }
+    ]
+});
 
 // Bypass (some) configuration and use escape hatch
 // -----------------------------------------------------------------------------

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cnn-server",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "description": "A simple, extendable server for CNN projects.",
   "license": "Apache-2.0",
   "private": true,
@@ -9,6 +9,7 @@
   "dependencies": {
     "cnn-logger": "1.5.0",
     "compression": "1.6.2",
+    "debug": "3.1.0",
     "express": "4.15.2",
     "hapi": "16.6.0"
   }

--- a/src/check-node-environment.js
+++ b/src/check-node-environment.js
@@ -15,7 +15,7 @@ function checkNodeEnvironment() {
     const supported = ['production', 'development', 'staging', 'test'];
     // Check if a value is set and that it is supported.
     if (supported.indexOf(process.env.NODE_ENV) === -1) {
-        log.warn(`NODE_ENV ${process.env.NODE_ENV} should be one of ${supported}`);
+        log.important(`process.env.NODE_ENV of "${process.env.NODE_ENV}" is not supported - it should be one of: ${supported}`);
     }
 }
 

--- a/src/config.js
+++ b/src/config.js
@@ -7,11 +7,6 @@ const config = {
     enableStatic: false,
     staticPath: '/static',
     staticDirectory: './dist',
-    logging: {
-        console: {
-            logLevel: 'error'
-        }
-    },
     middleware: [],
     routes: []
 };

--- a/src/errors.js
+++ b/src/errors.js
@@ -8,7 +8,7 @@ function handleNoMatch(req, res, next) {
 function handleError(err, req, res, next) {
     const code = err.statusCode || 500;
     const message = err.message || 'Here be dragons.';
-    log.fatal(`Sent error ${code} response for URI ${req.url}`);
+    log.error(`Sent error ${code} response for URI ${req.url}`);
     res.status(code).send(message);
 }
 

--- a/src/errors.js
+++ b/src/errors.js
@@ -1,13 +1,14 @@
 const HttpError = require('./http-error.js');
 
 function handleNoMatch(req, res, next) {
+    log.error(`Hit handleNoMatch middleware for ${req.url}`);
     next(new HttpError(`No match found for ${req.url}.`, 404));
 }
 
 function handleError(err, req, res, next) {
     const code = err.statusCode || 500;
     const message = err.message || 'Here be dragons.';
-    log.error(`Sent error ${code} response for URI ${req.url}`);
+    log.fatal(`Sent error ${code} response for URI ${req.url}`);
     res.status(code).send(message);
 }
 

--- a/src/express.js
+++ b/src/express.js
@@ -11,7 +11,7 @@ function start(app, config) {
     if (process.env.ENABLE_CLUSTER && cluster.isMaster) {
         os.cpus().forEach(c => cluster.fork());
         cluster.on('exit', function fork(worker) {
-            log.fatal(`Worker ${worker.id} died.`);
+            log.fatal(`Worker ${worker.id} died. Starting a new one.`);
             cluster.fork();
         });
     } else {

--- a/src/express.js
+++ b/src/express.js
@@ -11,7 +11,7 @@ function start(app, config) {
     if (process.env.ENABLE_CLUSTER && cluster.isMaster) {
         os.cpus().forEach(c => cluster.fork());
         cluster.on('exit', function fork(worker) {
-            log.error(`Worker ${worker.id} died.`);
+            log.fatal(`Worker ${worker.id} died.`);
             cluster.fork();
         });
     } else {

--- a/src/express.js
+++ b/src/express.js
@@ -1,15 +1,28 @@
+const os = require('os');
+const cluster = require('cluster');
+const http = require('http');
+const express = require('express');
+const debug = require('debug')('cnn-server:express');
+const compression = require('compression');
+const { healthcheckRoute } = require('./healthcheck.js');
+const { handleNoMatch, handleError } = require('./errors.js');
+
 function start(app, config) {
-    const { port } = config;
-    const http = require('http');
-    http.createServer(app).listen(port, () => {
-        log.important(`Service started on port: ${port}`);
-    });
-    // @TODO: Add error check
-    // @TODO: Add support for https
+    if (process.env.ENABLE_CLUSTER && cluster.isMaster) {
+        os.cpus().forEach(c => cluster.fork());
+        cluster.on('exit', function fork(worker) {
+            log.error(`Worker ${worker.id} died.`);
+            cluster.fork();
+        });
+    } else {
+        const { port } = config;
+        http.createServer(app).listen(port, function start() {
+            log.important(`Service started on port: ${port}`);
+        });
+    }
 }
 
 function handleErrors(app, callback) {
-    const { handleNoMatch, handleError } = require('./errors.js');
     // Default route to 404 unmatched things.
     app.all('*', handleNoMatch);
     // Error handler
@@ -18,13 +31,12 @@ function handleErrors(app, callback) {
 }
 
 function registerRoutes(app, { routes : r }, callback) {
-    const { healthcheckRoute } = require('./healthcheck.js');
     const routes = r.slice();
 
     routes.unshift(healthcheckRoute);
 
     routes.forEach(({ method = 'get', path, handler }) => {
-        log.info(`Registering route: path: ${path}, method: ${method}`);
+        debug(`Registering route: path: ${path}, method: ${method}`);
         app[method.toLowerCase()].call(app, path, handler);
     });
 
@@ -42,16 +54,16 @@ function registerMiddleware(app, express, config, callback) {
 
     middleware.forEach(middleware => {
         if (typeof middleware === 'function') {
-            log.important(`Registering middleware: ${middleware.name}`);
+            debug(`Registering middleware: ${middleware.name}`);
             app.use.call(app, middleware);
         } else {
             const { path = '/', handler } = middleware;
-            log.important(`Registering middleware: ${path}`);
+            debug(`Registering middleware: ${path}`);
             app.use.call(app, path, handler);
         }
     });
 
-    enableCompression && app.use(require('compression')());
+    enableCompression && app.use(compression());
     enableStatic && app.use(staticPath, express.static(staticDirectory));
 
     callback();
@@ -63,12 +75,8 @@ function handleEscapeHatch(escapeHatch, app, express, callback) {
 }
 
 function server(config, escapeHatch = null) {
-
-    const express = require('express');
     const app = express();
-
     app.disable('x-powered-by');
-
     const step5 = start.bind(null, app, config);
     const step4 = handleErrors.bind(null, app, step5);
     const step3 = registerRoutes.bind(null, app, config, step4);

--- a/src/healthcheck.js
+++ b/src/healthcheck.js
@@ -1,4 +1,3 @@
-const process = require('process');
 const { resolve } = require('path');
 
 /**
@@ -20,14 +19,9 @@ function healthcheck(packageJSON, additonalMetrics = {}) {
     }
 
     function metrics() {
-        const now = new Date();
         return Object.assign({}, {
             name: packageJSON.name,
-            versionPackage: packageJSON.version,
-            epochMS: now.getTime(),
-            utcDate: now.toUTCString(),
-            memoryUsage: process.memoryUsage(),
-            uptime: process.uptime() // uptime is in seconds
+            versionPackage: packageJSON.version
         }, additonalMetrics);
     };
 

--- a/src/index.js
+++ b/src/index.js
@@ -1,15 +1,22 @@
+global.log = require('./logging.js');
+const debug = require('debug')('cnn-server:init');
+const checkNodeEnvironment = require('./check-node-environment.js');
+
 function server(appConfig, escapeHatch = null) {
     const baseConfig = require('./config.js');
     const config = Object.assign({}, baseConfig, appConfig);
-    const log = global.log = require('./logging.js')(config.logging);
 
-    require('./check-node-environment.js')();
+    debug('merged configuration: ', config);
+
+    checkNodeEnvironment();
 
     switch (config.framework) {
         case 'hapi':
+            debug('Using Hapi framework');
             require('./hapi.js')(config, escapeHatch);
             break;
         case 'express':
+            debug('Using Express framework');
             require('./express.js')(config, escapeHatch);
             break;
         default:

--- a/src/logging.js
+++ b/src/logging.js
@@ -1,17 +1,26 @@
-function logging(options = {}) {
-    const log = global.log = require('cnn-logger')(options);
+const debug = require('debug')('cnn-server:logger');
 
-    log.important('Initializing Logging subsystem...');
-    log.silly('Running self check: silly');
-    log.debug('Running self check: debug');
-    log.verbose('Running self check: verbose');
-    log.info('Running self check: info');
-    log.warn('Running self check: warn');
-    log.error('Running self check: error');
-    log.fatal('Running self check: fatal');
-    log.important('Running self check: important');
+const log = require('cnn-logger')(process.env.LOGZIO_TOKEN ? {
+    console: {
+        logLevel: (process.env.KUBERNETES_PORT ? 'fatal' : (process.env.CONSOLE_LOG_LEVEL || process.env.LOG_LEVEL))
+    },
+    logzio: {
+        tags: [
+            process.env.PRODUCT && process.env.PRODUCT,
+            process.env.ENVIRONMENT && process.env.ENVIRONTMENT.toLowerCase() + '-env'
+        ]
+    }
+} : {});
 
-    return log;
-}
+debug(`Initializing Logging subsystem... LOG_LEVEL="${process.env.LOG_LEVEL}", CONSOLE_LOG_LEVEL="${process.env.CONSOLE_LOG_LEVEL}"`);
 
-module.exports = logging;
+log.silly('Running self check: silly');
+log.debug('Running self check: debug');
+log.verbose('Running self check: verbose');
+log.info('Running self check: info');
+log.warn('Running self check: warn');
+log.error('Running self check: error');
+log.fatal('Running self check: fatal');
+log.important('Running self check: important');
+
+module.exports = log;

--- a/src/logging.js
+++ b/src/logging.js
@@ -1,16 +1,25 @@
 const debug = require('debug')('cnn-server:logger');
 
+function generateTags(LOGZIO_TAGS) {
+    if (!LOGZIO_TAGS) {
+        console.error('No LOGZIO_TAGS have been defined.');
+        return null;
+    }
+    return LOGZIO_TAGS.split(',').map(i => i.trim()).filter(Boolean)
+}
+
 const log = require('cnn-logger')(process.env.LOGZIO_TOKEN ? {
     console: {
         logLevel: (process.env.KUBERNETES_PORT ? 'fatal' : (process.env.CONSOLE_LOG_LEVEL || process.env.LOG_LEVEL))
     },
     logzio: {
-        tags: [
-            process.env.PRODUCT && process.env.PRODUCT,
-            process.env.ENVIRONMENT && process.env.ENVIRONTMENT.toLowerCase() + '-env'
-        ]
+        tags: generateTags(process.env.LOGZIO_TAGS)
     }
 } : {});
+
+if (process.env.LOGZIO_TOKEN && !process.env.LOGZIO_TAGS) {
+    log.important('process.env.LOGZIO_TAGS is not defined, your logs will not be sent to logz.io. See cnn-server README.');
+}
 
 debug(`Initializing Logging subsystem... LOG_LEVEL="${process.env.LOG_LEVEL}", CONSOLE_LOG_LEVEL="${process.env.CONSOLE_LOG_LEVEL}"`);
 


### PR DESCRIPTION
# What
Updates for `cnn-server`

# Changes
- Update Logging
- Add support for clustering
- Update example code
- Add support for `debug` (start the application with `DEBUG=cnn-server*`
- Simplify healthcheck
- Refactor requires to be at the top of files

# Breaking Changes
- LOGGING - how options are passed into `cnn-logger`, these are controlled entirely via ENV vars now. See README env vars.

In order to use the logz.io transport, a consumer MUST provide:`LOGZIO_TOKEN`, `PRODUCT`, and `ENVIRONMENT` as environment variables.