### PR TITLE
Fix check for ENABLE_CLUSTER

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cnn-server",
-  "version": "0.5.1",
+  "version": "0.5.2",
   "description": "A simple, extendable server for CNN projects.",
   "license": "Apache-2.0",
   "private": true,

--- a/src/express.js
+++ b/src/express.js
@@ -8,7 +8,7 @@ const { healthcheckRoute } = require('./healthcheck.js');
 const { handleNoMatch, handleError } = require('./errors.js');
 
 function start(app, config) {
-    if (process.env.ENABLE_CLUSTER && cluster.isMaster) {
+    if (String(process.env.ENABLE_CLUSTER).toLowerCase() === 'true' && cluster.isMaster) {
         os.cpus().forEach(c => cluster.fork());
         cluster.on('exit', function fork(worker) {
             log.fatal(`Worker ${worker.id} died. Starting a new one.`);


### PR DESCRIPTION
Currently, setting `process.env.ENABLE_CLUSTER` to `false` evaluates to true. So we will always cluster if `ENABLE_CLUSTER` is set to any value. This PR removes the check for truthiness.